### PR TITLE
PWA-194: Checkout button doesn't work after canceled login

### DIFF
--- a/pages/Cart/components/PaymentBar/components/Content/components/CheckoutButton/index.jsx
+++ b/pages/Cart/components/PaymentBar/components/Content/components/CheckoutButton/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import I18n from '@shopgate/pwa-common/components/I18n';
 import Link from '@shopgate/pwa-common/components/Router/components/Link';
@@ -12,19 +12,19 @@ import styles from './style';
  * @returns {JSX}
  */
 const CheckoutButton = ({ isActive }) => (
-  <RippleButton
-    disabled={!isActive}
-    flat={false}
-    type="secondary"
-    className={styles.button}
-  >
-    <Link href={CHECKOUT_PATH}>
+  <Link href={CHECKOUT_PATH}>
+    <RippleButton
+      disabled={!isActive}
+      flat={false}
+      type="secondary"
+      className={styles.button}
+    >
       <I18n.Text
         className={styles.link}
         string="cart.checkout"
       />
-    </Link>
-  </RippleButton>
+    </RippleButton>
+  </Link>
 );
 
 CheckoutButton.propTypes = {

--- a/pages/Cart/subscriptions.js
+++ b/pages/Cart/subscriptions.js
@@ -1,0 +1,18 @@
+import { CART_PATH } from '@shopgate/pwa-common-commerce/cart/constants';
+import { routeDidEnter } from '@shopgate/pwa-common/streams/history';
+import toggleCartIcon from 'Components/Navigator/actions/toggleCartIcon';
+
+/**
+ * Cart subscriptions.
+ * @param {Function} subscribe The subscribe function.
+ */
+export default function cart(subscribe) {
+  const cartRouteDidEnter$ = routeDidEnter(CART_PATH);
+
+  /**
+   * Gets triggered on entering the cart route.
+   */
+  subscribe(cartRouteDidEnter$, ({ dispatch }) => {
+    dispatch(toggleCartIcon(false));
+  });
+}

--- a/pages/subscribers.js
+++ b/pages/subscribers.js
@@ -35,6 +35,7 @@ import search from 'Pages/Search/subscriptions';
 import reviews from 'Pages/Reviews/subscriptions';
 import filterbar from 'Components/FilterBar/subscriptions';
 import writeReview from 'Pages/WriteReview/subscriptions';
+import cart from 'Pages/Cart/subscriptions';
 import appConfig from '@shopgate/pwa-common/helpers/config';
 // Extensions
 import extensions from 'Extensions/subscribers';
@@ -81,6 +82,7 @@ const subscriptions = [
   search,
   reviews,
   writeReview,
+  cart,
   // Extensions
   ...extensions,
 ];


### PR DESCRIPTION
- make link wrap the ripplebutton
- add subscriber to handle correct navigator display