### PR TITLE
CCP-646: Black background on page transition

### DIFF
--- a/components/Viewport/style.js
+++ b/components/Viewport/style.js
@@ -9,6 +9,7 @@ css.global('html', {
 
 css.global('body', {
   userSelect: 'none',
+  backgroundColor: '#fff',
 });
 
 /**


### PR DESCRIPTION
- on iOS the page background isn't black anymore while route based bundles are loaded