### PR TITLE
PWA-660

### DIFF
--- a/components/ProductCard/index.jsx
+++ b/components/ProductCard/index.jsx
@@ -37,12 +37,6 @@ const ProductCard = ({
     itemType="http://schema.org/Product"
   >
     <ProductImage
-      classNames={
-        {
-        imageContainer: styles.updateImageContainer,
-        container: styles.updateContainer,
-        }
-      }
       itemProp="image"
       src={product.featuredImageUrl}
       alt={product.name}

--- a/components/ProductCard/style.js
+++ b/components/ProductCard/style.js
@@ -1,6 +1,10 @@
 import { css } from 'glamor';
 import colors from 'Styles/colors';
 
+/* Styles here are very fragile. There is mix of 3d and non-3d layers, border-radius, shadows, etc.
+ * If you for example apply translate3d to `container` it will break the border-radius
+ * inheritance at image and glow pseudo-element . */
+
 const container = css({
   position: 'relative',
   display: 'block',
@@ -46,14 +50,6 @@ const wishlist = css({
   transform: 'translate3d(0, -50%, 0)',
 }).toString();
 
-const updateImageContainer = css({
-  borderRadius: '0px',
-}).toString();
-
-const updateContainer = css({
-  borderRadius: '0px',
-}).toString();
-
 export default {
   badgeWrapper,
   basicPrice,
@@ -62,6 +58,4 @@ export default {
   priceWrapper,
   title,
   wishlist,
-  updateImageContainer,
-  updateContainer,
 };

--- a/components/ProductImage/__snapshots__/spec.jsx.snap
+++ b/components/ProductImage/__snapshots__/spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<ProductImage /> should render a placeholder if no src prop is provided 1`] = `
 <div
-  className="css-1lwoc2u"
+  className="css-3hjqnz"
 >
   <div
     className="css-y5kkpq"
@@ -16,21 +16,18 @@ exports[`<ProductImage /> should render a placeholder if no src prop is provided
       />
     </div>
   </div>
-  <div
-    className="css-n44iz3"
-  />
 </div>
 `;
 
 exports[`<ProductImage /> should render the image without a placeholder 1`] = `
 <div
-  className="css-1lwoc2u"
+  className="css-3hjqnz"
 >
   <Image
     alt={null}
     animating={true}
     backgroundColor="#fff"
-    className="css-1lwoc2u"
+    className="css-3hjqnz"
     classNames={
       Object {
         "container": null,
@@ -58,9 +55,6 @@ exports[`<ProductImage /> should render the image without a placeholder 1`] = `
     }
     src="http://placehold.it/300x300"
     transition={null}
-  />
-  <div
-    className="css-n44iz3"
   />
 </div>
 `;

--- a/components/ProductImage/index.jsx
+++ b/components/ProductImage/index.jsx
@@ -70,10 +70,6 @@ class ProductImage extends Component {
     };
   }
 
-  state = {
-    showPlaceholder: false,
-  };
-
   /**
    * Called when the component props change.
    * @param {Object} nextProps The new component properties
@@ -140,11 +136,6 @@ class ProductImage extends Component {
    * @return {JSX}
    */
   render() {
-    const glowClasses = classNames(
-      styles.glowContainer,
-      this.props.classNames.glowContainer
-    );
-
     const classes = classNames(
       styles.container,
       this.props.classNames.imageContainer
@@ -153,7 +144,6 @@ class ProductImage extends Component {
     return (
       <div className={classes}>
         {this.renderedContent}
-        <div className={glowClasses} />
       </div>
     );
   }

--- a/components/ProductImage/style.js
+++ b/components/ProductImage/style.js
@@ -6,19 +6,18 @@ const placeholderOffset = (1.0 - placeholderIconScale) * 50;
 
 const container = css({
   position: 'relative',
-  borderRadius: 3,
   overflow: 'hidden',
-}).toString();
-
-const glowContainer = css({
-  position: 'absolute',
-  top: 0,
-  bottom: 0,
-  left: 0,
-  right: 0,
-  boxShadow: 'inset 0 0 20px rgba(0, 0, 0, .05)',
-  zIndex: 1,
-  pointerEvents: 'none',
+  ':after': {
+    display: 'block',
+    content: '""',
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    boxShadow: 'inset 0 0 20px rgba(0, 0, 0, .05)',
+    pointerEvents: 'none',
+  },
 }).toString();
 
 const placeholderContainer = css({
@@ -52,7 +51,6 @@ const placeholder = css({
 
 export default {
   container,
-  glowContainer,
   placeholderContainer,
   placeholderContent,
   placeholder,

--- a/widgets/Liveshopping/index.jsx
+++ b/widgets/Liveshopping/index.jsx
@@ -68,7 +68,6 @@ const createProductSliderItem = ({
               <ProductImage
                 classNames={{
                   container: styles.updateImageContainer,
-                  glowContainer: styles.updateImageGlowContainer,
                 }}
                 src={featuredImageUrl}
                 alt={name}

--- a/widgets/Liveshopping/style.js
+++ b/widgets/Liveshopping/style.js
@@ -68,11 +68,6 @@ const updateImageContainer = css({
   borderBottomLeftRadius: variables.borderRadius.default,
 }).toString();
 
-const updateImageGlowContainer = css({
-  borderTopLeftRadius: variables.borderRadius.default,
-  borderBottomLeftRadius: variables.borderRadius.default,
-}).toString();
-
 const cardTitle = css({
   fontWeight: 500,
   lineHeight: 1.25,
@@ -108,5 +103,4 @@ export default {
   timer,
   cardInnerBox,
   updateImageContainer,
-  updateImageGlowContainer
 };

--- a/widgets/ProductSlider/style.js
+++ b/widgets/ProductSlider/style.js
@@ -6,7 +6,9 @@ const sliderContainer = css({
   marginLeft: 'auto',
   marginRight: 'auto',
   position: 'relative',
-  paddingBottom: 8,
+  // Must be 2px more than card's box shadow,
+  // (otherwise there's a white artifact on the iOS visible)
+  paddingBottom: 10,
 }).toString();
 
 const slider = css({


### PR DESCRIPTION
Fixing the broken top border-radius on the product card (there was none) + disappearing badges on scroll
- removed glow container, moved it to a pseudo element (to prevent border-radius)
- removed weird top: 50%, left:50% and then translate3d(-50%...), changed to top: 0, left: 0 (CCP-410 non regression)

Other fixes
- remove obsolete state property definition in ProductImage component
- fix for 2px white artifact below the product card box shadow visible on the productSlider widget